### PR TITLE
Refactored newSubmission method to set categories list

### DIFF
--- a/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/controllers/SubmissionController.java
+++ b/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/controllers/SubmissionController.java
@@ -99,7 +99,7 @@ public class SubmissionController {
 
     //Allows users to edit submission entity in DB
     @PatchMapping("/{id}")
-    public ResponseEntity<?> updateSubmission(@PathVariable Integer id, @RequestBody SubmissionFormDTO submissionFormDTO) {
+    public ResponseEntity<?> updateSubmission(@PathVariable Integer id, @RequestBody SubmissionFormDTO submissionFormDTO, HttpSession session) {
 
         //Finds submission by ID in repository
         Submission findInRepo = submissionRepository.findById(id).get();
@@ -111,9 +111,13 @@ public class SubmissionController {
         findInRepo.setDescription(submissionFormDTO.getDescription());
         findInRepo.setSubmissionReview(submissionFormDTO.getSubmissionReview());
 
+        List<Category> categoryList = (List<Category>) categoryRepository.findAllById(submissionFormDTO.getCategories());
+        findInRepo.setCategories(categoryList);
+
         //TODO: get user from session/authentication, currently holding dummy data to appease constructor
-        User user1 = userRepository.findByUsername("user1");
-        findInRepo.setUser(user1);
+        User user = authenticationController.getUserFromSession(session);
+//        User user1 = userRepository.findByUsername("user1");
+        findInRepo.setUser(user);
 
         //TODO: get placeID from Maps API address, currently holding dummy data to appease constructor
         findInRepo.setPlaceId("123abc");

--- a/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/controllers/SubmissionController.java
+++ b/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/controllers/SubmissionController.java
@@ -1,8 +1,10 @@
 package com.CherrySystems.ThirdPlace_Backend.controllers;
 
+import com.CherrySystems.ThirdPlace_Backend.models.Category;
 import com.CherrySystems.ThirdPlace_Backend.models.Submission;
 import com.CherrySystems.ThirdPlace_Backend.models.User;
 import com.CherrySystems.ThirdPlace_Backend.models.dto.SubmissionFormDTO;
+import com.CherrySystems.ThirdPlace_Backend.repositories.CategoryRepository;
 import com.CherrySystems.ThirdPlace_Backend.repositories.SubmissionRepository;
 import com.CherrySystems.ThirdPlace_Backend.repositories.UserRepository;
 import jakarta.persistence.Id;
@@ -29,6 +31,9 @@ public class SubmissionController {
     private UserRepository userRepository;
 
     @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
     private AuthenticationController authenticationController;
 
 
@@ -44,6 +49,9 @@ public class SubmissionController {
         newSubmission.setRating(submissionFormDTO.getRating());
         newSubmission.setDescription(submissionFormDTO.getDescription());
         newSubmission.setSubmissionReview(submissionFormDTO.getSubmissionReview());
+
+        List<Category> categoryList = (List<Category>) categoryRepository.findAllById(submissionFormDTO.getCategories());
+        newSubmission.setCategories(categoryList);
 
         //TODO: get user from session/authentication, currently holding dummy data to appease constructor
         User user = authenticationController.getUserFromSession(session);

--- a/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/models/dto/SubmissionFormDTO.java
+++ b/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/models/dto/SubmissionFormDTO.java
@@ -1,6 +1,9 @@
 package com.CherrySystems.ThirdPlace_Backend.models.dto;
 
 
+import com.CherrySystems.ThirdPlace_Backend.models.Category;
+
+import java.util.List;
 
 public class SubmissionFormDTO {
 
@@ -14,6 +17,8 @@ public class SubmissionFormDTO {
     private String description;
 
     private String submissionReview;
+
+    private List<Integer> categories;
 
     public String getLocationName() {
         return locationName;
@@ -53,5 +58,13 @@ public class SubmissionFormDTO {
 
     public void setSubmissionReview(String submissionReview) {
         this.submissionReview = submissionReview;
+    }
+
+    public List<Integer> getCategories() {
+        return categories;
+    }
+
+    public void setCategories(List<Integer> categories) {
+        this.categories = categories;
     }
 }

--- a/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/repositories/CategoryRepository.java
+++ b/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/repositories/CategoryRepository.java
@@ -4,6 +4,8 @@ import com.CherrySystems.ThirdPlace_Backend.models.Category;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface CategoryRepository extends CrudRepository<Category, Integer> {
 


### PR DESCRIPTION
### Summary:

- Added `categories` field to `SubmissionFormDTO`
- In the `SubmissionController` added code to get `categories` field from form, then find those `categories` in the database, then set them to the `newSubmission` `categories` list

### To Test:

- [ ] If you don't already have some catergories in your database, you can run the code below in your workbench and use these
```
INSERT INTO categories (category_name) VALUES
('Outdoors'),
('Indoors'),
('Community Center'),
('Cafe'),
('Library'),
('Park'),
('Free'),
('Paid');
```

- [ ] First log in a User on postman
- [ ] Then use `http://localhost:8080/api/submission/form` to submit a location with all necessary fields like below; `categories` will be entered as an array of `category` ID's
```
{ 
    "locationName": "Peggy's Party Supplies", 
    "locationAddress": "A cat tree near you", 
    "rating": "5", 
    "description": "All your party goods in one place!", 
    "submissionReview": "Free catnip and treats! Definitely coming back!",
    "categories": [1, 3, 6, 7]
}
```
- [ ] Check database to see if it is there, you should see the relations in `submission_categories`
- [ ] Edit submission by ID should work as well
- [ ] If not logged in, you should receive an error

> In postman, if you look at a submission or all submissions, it will look very very very long depending on how many categories are in the submission. This is because each category object also includes a array of related submission objects.