### PR TITLE
113 submission form passes placeid to back end

### DIFF
--- a/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/controllers/SubmissionController.java
+++ b/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/controllers/SubmissionController.java
@@ -50,15 +50,13 @@ public class SubmissionController {
 
         newSubmission.setLocationName(submissionFormDTO.getLocationName());
         newSubmission.setLocationAddress(submissionFormDTO.getLocationAddress());
+        newSubmission.setPlaceId(submissionFormDTO.getPlaceId());
         newSubmission.setRating(submissionFormDTO.getRating());
         newSubmission.setDescription(submissionFormDTO.getDescription());
         newSubmission.setSubmissionReview(submissionFormDTO.getSubmissionReview());
 
         List<Category> categoryList = (List<Category>) categoryRepository.findAllById(submissionFormDTO.getCategories());
         newSubmission.setCategories(categoryList);
-        
-        //TODO: get placeID from Maps API address, currently holding dummy data to appease constructor
-        newSubmission.setPlaceId("123abc");
 
         return submissionRepository.save(newSubmission);
     }
@@ -102,6 +100,7 @@ public class SubmissionController {
         //Updates submission data only for those that were changed
         findInRepo.setLocationName(submissionFormDTO.getLocationName());
         findInRepo.setLocationAddress(submissionFormDTO.getLocationAddress());
+        findInRepo.setPlaceId(submissionFormDTO.getPlaceId());
         findInRepo.setRating(submissionFormDTO.getRating());
         findInRepo.setDescription(submissionFormDTO.getDescription());
         findInRepo.setSubmissionReview(submissionFormDTO.getSubmissionReview());
@@ -113,9 +112,6 @@ public class SubmissionController {
         User user = authenticationController.getUserFromSession(session);
 //        User user1 = userRepository.findByUsername("user1");
         findInRepo.setUser(user);
-
-        //TODO: get placeID from Maps API address, currently holding dummy data to appease constructor
-        findInRepo.setPlaceId("123abc");
 
         //saves updated information to DB
         submissionRepository.save(findInRepo);

--- a/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/models/dto/SubmissionFormDTO.java
+++ b/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/models/dto/SubmissionFormDTO.java
@@ -12,6 +12,8 @@ public class SubmissionFormDTO {
 
     private String locationAddress;
 
+    private String placeId;
+
     private Integer rating;
 
     private String description;
@@ -34,6 +36,14 @@ public class SubmissionFormDTO {
 
     public void setLocationAddress(String locationAddress) {
         this.locationAddress = locationAddress;
+    }
+
+    public String getPlaceId() {
+        return placeId;
+    }
+
+    public void setPlaceId(String placeId) {
+        this.placeId = placeId;
     }
 
     public Integer getRating() {

--- a/ThirdPlace-UI/src/components/Map/AddressBar.jsx
+++ b/ThirdPlace-UI/src/components/Map/AddressBar.jsx
@@ -37,11 +37,6 @@ export default function AddressBar({
         return;
       }
 
-      console.log(`autocomplete.getplace().place_id: ${place.place_id}`);
-      console.log(
-        `autocomplete.getplace().address: ${place.formatted_address}`
-      );
-
       //TODO: block users from posting form without valid place geometry
 
       // if (!place.geometry) {

--- a/ThirdPlace-UI/src/components/Map/AddressBar.jsx
+++ b/ThirdPlace-UI/src/components/Map/AddressBar.jsx
@@ -1,98 +1,88 @@
 import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
-import React, {useState, useEffect, useRef, useCallback} from 'react';
-
+import React, { useState, useEffect, useRef, useCallback } from "react";
 
 async function initAutoComplete(inputRef, onPlaceChanged) {
-
-  const {Autocomplete} = await google.maps.importLibrary("places");
+  const { Autocomplete } = await google.maps.importLibrary("places");
 
   const autocomplete = new google.maps.places.Autocomplete(
     // document.getElementById("autocomplete"),
-    inputRef, 
+    inputRef,
     {
-      fields: ["formatted_address", "place_id", "geometry"]
+      fields: ["formatted_address", "place_id", "geometry"],
     }
   );
 
   //trigger place selection handler
-  autocomplete.addListener("place_changed", () => onPlaceChanged(autocomplete.getPlace()));
+  autocomplete.addListener("place_changed", () =>
+    onPlaceChanged(autocomplete.getPlace())
+  );
 
   return autocomplete;
-//if you need to call getplace again, call in onplacechanged handler
 }
 
-export default function AddressBar({address, setAddress, placeId, setPlaceId}) {
-
+export default function AddressBar({
+  address,
+  setAddress,
+  placeId,
+  setPlaceId,
+}) {
   const [autocomplete, setAutocomplete] = useState(),
   inputRef = useRef(null);
 
-//TODO write handler for place selection checking if a valid selection is made, and if so, grab placeId
-const onPlaceChanged = useCallback((place) => {
+  // useCallback hook prevents unnecessary recreation of function with each re-render
+  const onPlaceChanged = useCallback(
+    (place) => {
+      if (!place) {
+        console.log(place);
+        return;
+      }
 
-  if (!place) {
-    console.log(place);
-    return;
-  }
-  
-  console.log(`autocomplete: ${place}`);
-  // console.log(`autocomplete.getplace(): ${autocomplete.getPlace()}`);
-  console.log(`autocomplete.getplace().place_id: ${place.place_id}`)
-  console.log(`autocomplete.getplace().address: ${place.formatted_address}`)
+      console.log(`autocomplete.getplace().place_id: ${place.place_id}`);
+      console.log(
+        `autocomplete.getplace().address: ${place.formatted_address}`
+      );
 
-  // const place = autocomplete.getPlace();
-  // console.log(`autocomplete.getplace().place_id: ${place.place_id}`)
+      //TODO: block users from posting form without valid place geometry
 
+      // if (!place.geometry) {
+      //   console.log("NOT valid address");
+      //   console.log(`place name: ${place.name}`)
+      // } else {
+      //   console.log(`valid address found: ${place.name}`);
 
-  // // const place = autocomplete.getPlace();
-  // console.log(`place name: ${place.formatted_address}`)
-  // console.log(`place geometry: ${place.geometry}`)
-  // console.log(`place id: ${place.place_id}`)
+      setPlaceId(place.place_id);
+      setAddress(place.formatted_address);
+    },
+    [setPlaceId, setAddress]
+  );
 
-  // if (!place.geometry) {
-  //   // document.getElementById("autocomplete").value = "Enter valid address...";
-  //   console.log("NOT valid address");
-  //   console.log(`place name: ${place.name}`)
-  // } else {
-  //   console.log(`valid address found: ${place.name}`);
-    
-    setPlaceId(place.place_id);
-    setAddress(place.formatted_address);
-  // }
-}, [setPlaceId, setAddress]);
-
-useEffect(() => {
-(async () => {
-if (inputRef.current == null) 
-  return;
-else {
-  const ac = await initAutoComplete(inputRef.current, onPlaceChanged).catch(ex => {
-    throw Error(`initAutoComplete: ${ex.toString()}`);
-  });
-  setAutocomplete(ac);
-}
-})();
-}, [inputRef.current, onPlaceChanged]);
-
-
-console.log(`place id and address hook values outside functions: ${placeId}, ${address}`);
-
-
-
-
-//TODO: block users from posting form without valid place geometry: validate with a boolean useState hook passed up to parent?
-//TODO: save PlaceId as a value for back end
+  useEffect(() => {
+    (async () => {
+      if (inputRef.current == null) return;
+      else {
+        const ac = await initAutoComplete(
+          inputRef.current,
+          onPlaceChanged
+        ).catch((ex) => {
+          throw Error(`initAutoComplete: ${ex.toString()}`);
+        });
+        setAutocomplete(ac);
+      }
+    })();
+  }, [inputRef.current, onPlaceChanged]);
 
   return (
     <>
-            <label>
-              Address: <br></br>
-              <input name="locationAddress" 
-              id="autocomplete"
-              ref={inputRef}
-              onChange={onPlaceChanged}
-              placeholder="Enter valid address..."
-            />
-            </label>
+      <label>
+        Address: <br></br>
+        <input
+          name="locationAddress"
+          id="autocomplete"
+          ref={inputRef}
+          onChange={onPlaceChanged}
+          placeholder="Enter valid address..."
+        />
+      </label>
     </>
   );
 }

--- a/ThirdPlace-UI/src/components/Map/AddressBar.jsx
+++ b/ThirdPlace-UI/src/components/Map/AddressBar.jsx
@@ -1,5 +1,5 @@
 import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
-import React, {useState, useEffect, useRef} from 'react';
+import React, {useState, useEffect, useRef, useCallback} from 'react';
 
 
 async function initAutoComplete(inputRef, onPlaceChanged) {
@@ -26,21 +26,8 @@ export default function AddressBar({address, setAddress, placeId, setPlaceId}) {
   const [autocomplete, setAutocomplete] = useState(),
   inputRef = useRef(null);
 
-useEffect(() => {
-(async () => {
-if (inputRef.current == null) 
-  return;
-else {
-  const ac = await initAutoComplete(inputRef.current, onPlaceChanged).catch(ex => {
-    throw Error(`initAutoComplete: ${ex.toString()}`);
-  });
-  setAutocomplete(ac);
-}
-})();
-}, [inputRef.current]);
-
 //TODO write handler for place selection checking if a valid selection is made, and if so, grab placeId
-function onPlaceChanged(place) {
+const onPlaceChanged = useCallback((place) => {
 
   if (!place) {
     console.log(place);
@@ -70,8 +57,26 @@ function onPlaceChanged(place) {
     setPlaceId(place.place_id);
     setAddress(place.formatted_address);
   // }
+}, [setPlaceId, setAddress]);
+
+useEffect(() => {
+(async () => {
+if (inputRef.current == null) 
+  return;
+else {
+  const ac = await initAutoComplete(inputRef.current, onPlaceChanged).catch(ex => {
+    throw Error(`initAutoComplete: ${ex.toString()}`);
+  });
+  setAutocomplete(ac);
 }
+})();
+}, [inputRef.current, onPlaceChanged]);
+
+
 console.log(`place id and address hook values outside functions: ${placeId}, ${address}`);
+
+
+
 
 //TODO: block users from posting form without valid place geometry: validate with a boolean useState hook passed up to parent?
 //TODO: save PlaceId as a value for back end

--- a/ThirdPlace-UI/src/components/Map/AddressBar.jsx
+++ b/ThirdPlace-UI/src/components/Map/AddressBar.jsx
@@ -1,62 +1,60 @@
 import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
-import React, {useState, useRef} from 'react';
+import React, {useState, useEffect} from 'react';
 
+
+async function initAutoComplete() {
+
+  const {Autocomplete} = await google.maps.importLibrary("places");
+
+  const autocomplete = new google.maps.places.Autocomplete(
+    document.getElementById("autocomplete"),
+    {
+      fields: ["formatted_address", "place_id", "geometry"]
+    }
+  );
+
+  //trigger place selection handler
+  // autocomplete.addListener("place_changed", onPlaceChanged);
+
+  return autocomplete.getPlace();
+
+}
 
 export default function AddressBar({address, setAddress, placeId, setPlaceId}) {
 
-  let autocomplete;
-  
-async function initAutoComplete() {
+  const [place, setPlace] = useState();
 
-    const {Autocomplete} = await google.maps.importLibrary("places");
-
-    autocomplete = new google.maps.places.Autocomplete(
-      document.getElementById("autocomplete"),
-      {
-        fields: ["name", "place_id", "geometry"]
-      }
-    );
-    //trigger place selection handler
-    autocomplete.addListener("place_changed", onPlaceChanged);
-
-}
-//TODO delete when passed up
-// const [address, setAddress] = useState("");
-// const [placeId, setPlaceId] = useState("");
-// const inputRef = useRef(null);
+  useEffect(() => {
+    (async () => setPlace(await initAutoComplete()))();
+  }, []);
 
 //TODO write handler for place selection checking if a valid selection is made, and if so, grab placeId
 function onPlaceChanged() {
-  const place = autocomplete.getPlace();
-  console.log(`place name: ${place.name}`)
+
+  if (!place) {
+    return;
+  }
+
+  // const place = autocomplete.getPlace();
+  console.log(`place name: ${place.formatted_address}`)
   console.log(`place geometry: ${place.geometry}`)
   console.log(`place id: ${place.place_id}`)
 
-
   if (!place.geometry) {
-    document.getElementById("autocomplete").value = "Enter valid address...";
+    // document.getElementById("autocomplete").value = "Enter valid address...";
     console.log("NOT valid address");
     console.log(`place name: ${place.name}`)
-    // console.log(`inputRef: ${inputRef.current.value}`);
   } else {
-    // document.getElementById("details").innerHTML = place.name;
     console.log(`valid address found: ${place.name}`);
     
     setPlaceId(place.place_id);
-    setAddress(place.name);
-
-    // state value not initialized
-    console.log(`place id and address hook values: ${placeId}, ${address}`);
-
+    setAddress(place.formatted_address);
   }
 }
 console.log(`place id and address hook values outside functions: ${placeId}, ${address}`);
 
-//TODO: block users from posting form without valid place geometry
+//TODO: block users from posting form without valid place geometry: validate with a boolean useState hook passed up to parent?
 //TODO: save PlaceId as a value for back end
-
-  initAutoComplete();
-
 
   return (
     <>
@@ -64,8 +62,8 @@ console.log(`place id and address hook values outside functions: ${placeId}, ${a
               Address: <br></br>
               <input name="locationAddress" 
               id="autocomplete"
+              onChange={onPlaceChanged}
               placeholder="Enter valid address..."
-              // ref={inputRef}
             />
             </label>
     </>

--- a/ThirdPlace-UI/src/components/Map/AddressBar.jsx
+++ b/ThirdPlace-UI/src/components/Map/AddressBar.jsx
@@ -17,7 +17,7 @@ async function initAutoComplete() {
   // autocomplete.addListener("place_changed", onPlaceChanged);
 
   return autocomplete.getPlace();
-
+//if you need to call getplace again, call in onplacechanged handler
 }
 
 export default function AddressBar({address, setAddress, placeId, setPlaceId}) {

--- a/ThirdPlace-UI/src/components/Map/AddressBar.jsx
+++ b/ThirdPlace-UI/src/components/Map/AddressBar.jsx
@@ -37,6 +37,7 @@ const onPlaceChanged = useCallback((place) => {
   console.log(`autocomplete: ${place}`);
   // console.log(`autocomplete.getplace(): ${autocomplete.getPlace()}`);
   console.log(`autocomplete.getplace().place_id: ${place.place_id}`)
+  console.log(`autocomplete.getplace().address: ${place.formatted_address}`)
 
   // const place = autocomplete.getPlace();
   // console.log(`autocomplete.getplace().place_id: ${place.place_id}`)

--- a/ThirdPlace-UI/src/components/submission/SubmissionForm.jsx
+++ b/ThirdPlace-UI/src/components/submission/SubmissionForm.jsx
@@ -76,7 +76,7 @@ const SubmissionForm = () => {
 
     } 
 
-    console.log(`Location Name: ${submissionName} Prop address: ${address} Prop placeId: ${placeId}`);
+    // console.log(`Location Name: ${submissionName} Prop address: ${address} Prop placeId: ${placeId}`);
 
     return (
         <>

--- a/ThirdPlace-UI/src/components/submission/SubmissionForm.jsx
+++ b/ThirdPlace-UI/src/components/submission/SubmissionForm.jsx
@@ -76,7 +76,7 @@ const SubmissionForm = () => {
 
     } 
 
-    // console.log(`Location name: ${submissionData.locationName} Location Address: ${submissionData.locationAddress} Prop address: ${address} Prop placeId: ${placeId}`);
+    console.log(`Prop address: ${address} Prop placeId: ${placeId}`);
 
     return (
         <>

--- a/ThirdPlace-UI/src/components/submission/SubmissionForm.jsx
+++ b/ThirdPlace-UI/src/components/submission/SubmissionForm.jsx
@@ -21,17 +21,6 @@ const SubmissionForm = () => {
     const navigate = useNavigate();
     
     const [submissionList, setSubmissionList] = useState([]);
-
-    // Previous data state
-    // const [submissionData, setSubmissionData] = useState({
-    //     locationName: '',
-    //     locationAddress: '',
-    //     description: '',
-    //     rating: 4, 
-    //     submissionReview: 'This place has awesome coffee!', 
-    //     categories: []
-    // });
-
    
     // fetches an array of submission objects from database each time the form is initialized//
     useEffect(() => {
@@ -80,7 +69,7 @@ const SubmissionForm = () => {
 
         // if form has no empty fields and location isn't in database, add new submission, alert user submission created, and reload SubmitLocation page
         if (submissionName !== "" && address !== "" && description !== "" && validLocation(submissionName)) {
-            addSubmission(submissionName, address, description, categories);
+            addSubmission(submissionName, address, placeId, description, categories);
             alert("Submission successfully created!");
             navigate('../'+submissionName, {replace: true});
         } 

--- a/ThirdPlace-UI/src/components/submission/SubmissionForm.jsx
+++ b/ThirdPlace-UI/src/components/submission/SubmissionForm.jsx
@@ -87,7 +87,7 @@ const SubmissionForm = () => {
 
     } 
 
-    console.log(`Prop address: ${address} Prop placeId: ${placeId}`);
+    console.log(`Location Name: ${submissionName} Prop address: ${address} Prop placeId: ${placeId}`);
 
     return (
         <>

--- a/ThirdPlace-UI/src/service/SubmissionService.js
+++ b/ThirdPlace-UI/src/service/SubmissionService.js
@@ -35,10 +35,11 @@ export const fetchSubmissions = async () => {
 
 //  Add new submission  //
 
-export const addSubmission = async (locationName, locationAddress, description, categories) => {
+export const addSubmission = async (locationName, locationAddress, placeId, description, categories) => {
    const submissonData = {
     locationName, 
     locationAddress, 
+    placeId,
     description,
     rating: 4,
     submissionReview: 'This place has awesome coffee!',


### PR DESCRIPTION
### Summary

- On submission form, Google maps Autocomplete API no longer makes excessive calls; should be no more than 3 API calls per input change
- Selecting a Google address populates address and grabs the placeId for that address
- Submitting will save both address and associated placeId to database

#### Notes:
- You may confirm Place ID's for testing using Google's PlaceId finder. https://developers.google.com/maps/documentation/places/web-service/place-id
- You may also uncomment line 79 on SubmissionForm.jsx to preview form values.
- Issue #121 created for additional validation to ensure users select a Place address 