### PR TITLE
138 User usernames go to that users profile

### DIFF
--- a/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/controllers/AuthenticationController.java
+++ b/ThirdPlace-Backend/src/main/java/com/CherrySystems/ThirdPlace_Backend/controllers/AuthenticationController.java
@@ -170,6 +170,19 @@ public class AuthenticationController {
         return ResponseEntity.ok(user);
     }
 
+//    Find user by username
+    @GetMapping("/{username}")
+    public ResponseEntity<?> getUserByUsername(@PathVariable String username) {
+        User user = userRepository.findByUsername(username);
+
+        if (user == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body("User not found!");
+        }
+
+        return ResponseEntity.ok(user);
+    }
+
+
 //    Logout
     @GetMapping("/logout")
     public ResponseEntity<?> logout(HttpServletRequest request){

--- a/ThirdPlace-UI/src/components/pages/OthersUserProfile.jsx
+++ b/ThirdPlace-UI/src/components/pages/OthersUserProfile.jsx
@@ -15,7 +15,7 @@ export default function OthersUserProfile() {
   const { isAuthenticated, user } = useAuth();
   // If there is a url param, then use param username/id to populate data
   const { username } = useParams();
-  const [otherUser, setOtherUser] = useState();
+  const [otherUser, setOtherUser] = useState({});
   const [favorites, setFavorites] = useState([]);
   const [submissionList, setSubmissionList] = useState([]);
   const [reviews, setReviews] = useState([]);
@@ -94,7 +94,7 @@ export default function OthersUserProfile() {
             <section>
               <h1>{username}'s Profile Page</h1>
 
-              <ProfileInfoCard/>
+              <ProfileInfoCard otherUser={otherUser}/>
 
               <div className='review-card-favorites'>
                 <div className='review-card-header'>

--- a/ThirdPlace-UI/src/components/pages/OthersUserProfile.jsx
+++ b/ThirdPlace-UI/src/components/pages/OthersUserProfile.jsx
@@ -2,17 +2,24 @@ import React, { useState, useEffect } from 'react';
 import ProfileInfoCard from '../user/ProfileInfoCard';
 import Navbar from '../navigation/Navbar';
 import { Link, useNavigate, useParams } from 'react-router-dom';
-import { useAuth } from "../../context/AuthContext";
 import FavoriteList from '../user/FavoriteList';
 import SubmissionsByUser from '../user/SubmissionsByUser';
 import { fetchSubmissions } from '../../service/SubmissionService';
+import { getUserByUsername } from '../../service/UserServices';
 
 export default function OthersUserProfile() {
   // If there is a url param, then use param username/id to populate data
   let { otherUser } = useParams();
+  const [user, setUser] = useState();
 
-  const { isAuthenticated, user } = useAuth();
-  const navigate = useNavigate();
+  useEffect(() => {
+    getUserByUsername({otherUser})
+    .then(setUser)
+    .catch((error) => {
+      console.error("Unable to fetch all submissions.", error);
+    });
+  }, [otherUser]);
+
   const [favorites, setFavorites] = useState([]);
   const [submissionList, setSubmissionList] = useState([]);
 
@@ -30,7 +37,7 @@ export default function OthersUserProfile() {
     fetchSubmissions()
       .then(setSubmissionList)
       .catch((error) => {
-          console.error("Unable to fetch all submissions.", error);
+        console.error("Unable to fetch all submissions.", error);
       });
   }, []);
 

--- a/ThirdPlace-UI/src/components/pages/OthersUserProfile.jsx
+++ b/ThirdPlace-UI/src/components/pages/OthersUserProfile.jsx
@@ -7,7 +7,7 @@ import FavoriteList from '../user/FavoriteList';
 import SubmissionsByUser from '../user/SubmissionsByUser';
 import { fetchSubmissions } from '../../service/SubmissionService';
 
-export default function UserProfile() {
+export default function OthersUserProfile() {
   // If there is a url param, then use param username/id to populate data
   let { otherUser } = useParams();
 

--- a/ThirdPlace-UI/src/components/pages/UserProfile.jsx
+++ b/ThirdPlace-UI/src/components/pages/UserProfile.jsx
@@ -1,20 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import ProfileInfoCard from '../user/ProfileInfoCard';
 import Navbar from '../navigation/Navbar';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from "../../context/AuthContext";
 import FavoriteList from '../user/FavoriteList';
 import SubmissionsByUser from '../user/SubmissionsByUser';
 import { fetchSubmissions } from '../../service/SubmissionService';
-import AdditionalUserReviews from '../submission/AdditionalUserReviews';
 import axios from 'axios';
-import RenderDateAndTime from '../condensed-submission/DateTimeStamp';
 import RenderDateAndTimeForReviews from '../condensed-submission/DateTimeStampForReviews';
 
 export default function UserProfile() {
-  // If there is a url param, then use param username/id to populate data
-  let { otherUser } = useParams();
-
   const { isAuthenticated, user } = useAuth();
   const navigate = useNavigate();
   const [submissionList, setSubmissionList] = useState([]);
@@ -84,97 +79,95 @@ export default function UserProfile() {
     return stars.join("") + (" " + rating);
   };
 
-  if (submissionList.length !== 0) {
-    return (
-      <div>
-          <Navbar/>
-          {user === null ? (
-            <section className='review-card'>
-                <h1>Log in to see Profile page!</h1>
-                <br />
-                <p>
-                    <Link to={{ pathname: '/login', state: { user, isAuthenticated }}}>Go to Login</Link>
-                </p>
-            </section>
-          ) : (
-            <section>
-              <h1>{user.username}'s Profile Page</h1>
+  return (
+    <div>
+        <Navbar/>
+        {user === null ? (
+          <section className='review-card'>
+              <h1>Log in to see Profile page!</h1>
+              <br />
+              <p>
+                  <Link to={{ pathname: '/login', state: { user, isAuthenticated }}}>Go to Login</Link>
+              </p>
+          </section>
+        ) : (
+          <section>
+            <h1>{user.username}'s Profile Page</h1>
 
-              <ProfileInfoCard/>
+            <ProfileInfoCard/>
 
-              <div className='review-card-favorites'>
-                <div className='review-card-header'>
-                  <h3>Submitted Locations</h3>
-                </div>
-                <div className='review-card-content'>
-                  {/* Renders the list of submitted locations in condensed condition */}
-                  {submissionArrByUser.length > 0 ? (
-                    <SubmissionsByUser submissionArrByUser={submissionArrByUser} />
-                  ) : (
-                    <p>No locations yet.</p>
-                  )}
-                </div>
+            <div className='review-card-favorites'>
+              <div className='review-card-header'>
+                <h3>Submitted Locations</h3>
               </div>
-
-              <div className='review-card-favorites'>
-                <div className='review-card-header'>
-                  <h3>Favorite Locations</h3>
-                </div>
-                <div className='review-card-content'>
-                  {/* Renders the list of favorite locations in condensed condition */}
-                  {favorites.length > 0 ? (
-                    <FavoriteList favorites={favorites.map(favorite => favorite.submission)} />
-                  ) : (
-                    <p>No favorite locations yet.</p>
-                  )}
-                </div>
+              <div className='review-card-content'>
+                {/* Renders the list of submitted locations in condensed condition */}
+                {submissionArrByUser.length > 0 ? (
+                  <SubmissionsByUser submissionArrByUser={submissionArrByUser} />
+                ) : (
+                  <p>No locations yet.</p>
+                )}
               </div>
+            </div>
 
-              <div className='review-card-favorites'>
-                <div className='review-card-header'>
-                  <h3>{user.username}'s Reviews</h3>
-                </div>
-                <div className='review-card-content'>
-                  {/* Renders a list of reviews made by current user */}
-                  {reviews.length > 0 ? (
-                    <div className=''>
-                      {<table className="table table-striped border shadow">
-                          <tbody>
-                              {reviews.map((review) => (
-                                  <tr key={review.id}>
-                                    <td>
-                                      <span>
-                                        <Link to={`../${review.submission.locationName}`}> {review.submission.locationName} </Link>
-                                      </span>
-                                      <br/>
-                                      <br/>
-                                      <span><b>Review:</b> {review.reviewText}</span>
-                                      <br/>
-                                      <br/>
-                                      <font size="2" className=''>Submitted {RenderDateAndTimeForReviews(review)}</font>
-                                    </td>
-                                    <td>
-                                      <br/>
-                                      <br/>
-                                      {renderStars(review.rating)}
-                                    </td>
-                                  </tr>
-                              ))}
-                          </tbody>
-                      </table>}
-                    </div>
-                  ) : (
-                    <p>No reviews yet.</p>
-                  )}
-                </div>
+            <div className='review-card-favorites'>
+              <div className='review-card-header'>
+                <h3>Favorite Locations</h3>
               </div>
-            </section>
-          )}
+              <div className='review-card-content'>
+                {/* Renders the list of favorite locations in condensed condition */}
+                {favorites.length > 0 ? (
+                  <FavoriteList favorites={favorites.map(favorite => favorite.submission)} />
+                ) : (
+                  <p>No favorite locations yet.</p>
+                )}
+              </div>
+            </div>
 
-          <p className="gray-text">
-            <center>🍒 Powered by Cherry Systems</center>
-          </p>
-      </div>
-    )
-  };
-}
+            <div className='review-card-favorites'>
+              <div className='review-card-header'>
+                <h3>{user.username}'s Reviews</h3>
+              </div>
+              <div className='review-card-content'>
+                {/* Renders a list of reviews made by current user */}
+                {reviews.length > 0 ? (
+                  <div className=''>
+                    {<table className="table table-striped border shadow">
+                        <tbody>
+                            {reviews.map((review) => (
+                                <tr key={review.id}>
+                                  <td>
+                                    <span>
+                                      <Link to={`../${review.submission.locationName}`}> {review.submission.locationName} </Link>
+                                    </span>
+                                    <br/>
+                                    <br/>
+                                    <span><b>Review:</b> {review.reviewText}</span>
+                                    <br/>
+                                    <br/>
+                                    <font size="2" className=''>Submitted {RenderDateAndTimeForReviews(review)}</font>
+                                  </td>
+                                  <td>
+                                    <br/>
+                                    <br/>
+                                    {renderStars(review.rating)}
+                                  </td>
+                                </tr>
+                            ))}
+                        </tbody>
+                    </table>}
+                  </div>
+                ) : (
+                  <p>No reviews yet.</p>
+                )}
+              </div>
+            </div>
+          </section>
+        )}
+
+        <p className="gray-text">
+          <center>🍒 Powered by Cherry Systems</center>
+        </p>
+    </div>
+  )
+};

--- a/ThirdPlace-UI/src/components/submission/AdditionalUserReviews.jsx
+++ b/ThirdPlace-UI/src/components/submission/AdditionalUserReviews.jsx
@@ -64,7 +64,7 @@ export default function AdditionalUserReviews({ submissionId }) {
             <tbody>
             {reviews.map(review => (
               <tr key={review.id} className="review-card-for-reviews">
-                <h4 className='user-review-username-title'>{review.user.username}</h4>
+                <h4 className='user-review-username-title'><Link to={`../profile/${review.user.username}`}> {review.user.username} </Link></h4>
                 <font size="2" className='submitted-date-in-reviews'>Submitted {RenderDateAndTime(review.submission)}</font><br></br>
                 <p className='user-review-rating'>Rating: {renderStars(review.rating)}</p>
                 <p className='user-reviewText'>{review.reviewText}</p>

--- a/ThirdPlace-UI/src/components/submission/AdditionalUserReviews.jsx
+++ b/ThirdPlace-UI/src/components/submission/AdditionalUserReviews.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import RenderDateAndTime from '../condensed-submission/DateTimeStamp';
 import StarRating from './StarRating';
+import { Link } from 'react-router-dom';
 
 export default function AdditionalUserReviews({ submissionId }) {
   const [reviews, setReviews] = useState([]);

--- a/ThirdPlace-UI/src/components/submission/AdditionalUserReviews.jsx
+++ b/ThirdPlace-UI/src/components/submission/AdditionalUserReviews.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import RenderDateAndTime from '../condensed-submission/DateTimeStamp';
+import { Link } from 'react-router-dom';
 
 export default function AdditionalUserReviews({ submissionId }) {
   const [reviews, setReviews] = useState([]);
@@ -60,7 +61,9 @@ export default function AdditionalUserReviews({ submissionId }) {
       {reviews.length > 0 ? (
         reviews.map(review => (
           <div key={review.id} className="review-card">
-            <h4>{review.user.username}</h4>
+            <h4>
+              <Link to={`../profile/:username`}> {review.user.username} </Link>
+            </h4>
             <font size="2">Submitted {RenderDateAndTime(review.submission)}</font><br></br>
             <p>Rating: {renderStars(review.rating)}</p>
             <p>{review.reviewText}</p>

--- a/ThirdPlace-UI/src/components/user/CherryScoreBadge.jsx
+++ b/ThirdPlace-UI/src/components/user/CherryScoreBadge.jsx
@@ -14,7 +14,7 @@ export const CherryScoreBadge = ({otherUser}) => {
         if (propOtherUser) {
             setSelectedUser(propOtherUser.cherryPoints)
         }
-    }, []);
+    }, [propOtherUser]);
 
     return (
         <div className='for-padding'>
@@ -24,7 +24,7 @@ export const CherryScoreBadge = ({otherUser}) => {
                     Cherry Score:
                 </p>
                 <p className='cherryPoints-and-img'>
-                    {user.cherryPoints}
+                    {selectedUser}
                     <img src={cherryNoLeaf}></img>
                 </p>
                 </div>

--- a/ThirdPlace-UI/src/components/user/CherryScoreBadge.jsx
+++ b/ThirdPlace-UI/src/components/user/CherryScoreBadge.jsx
@@ -1,24 +1,36 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import './ProfileInfoCard.css';
 import cherryNoLeaf from '../../assets/cherries-no-leaf.png'
 import { useAuth } from '../../context/AuthContext';
 
-export const CherryScoreBadge = () => {
+export const CherryScoreBadge = ({otherUser}) => {
     const { user } = useAuth();
+
+    const propOtherUser = otherUser;
+
+    const [selectedUser, setSelectedUser] = useState(user.cherryPoints);
+
+    useEffect(() => {
+        if (propOtherUser) {
+            setSelectedUser(propOtherUser.cherryPoints)
+        }
+    }, []);
 
     return (
         <div className='for-padding'>
-           {user.cherryPoints > 0 ? ( 
-            <div className='cherry-img-and-score'>
-            <p className='cherry-score-title'>
-                Cherry Score:
-            </p>
-            <p className='cherryPoints-and-img'>
-                {user.cherryPoints}
-                <img src={cherryNoLeaf}></img>
-            </p>
-            </div>
-            ) : ("No Cherry Points Yet!")}
+            {selectedUser > 0 ? ( 
+                <div className='cherry-img-and-score'>
+                <p className='cherry-score-title'>
+                    Cherry Score:
+                </p>
+                <p className='cherryPoints-and-img'>
+                    {user.cherryPoints}
+                    <img src={cherryNoLeaf}></img>
+                </p>
+                </div>
+            ) : (
+                "No Cherry Points Yet!")
+            }
         </div>
     )
 }

--- a/ThirdPlace-UI/src/components/user/ProfileImage.jsx
+++ b/ThirdPlace-UI/src/components/user/ProfileImage.jsx
@@ -7,29 +7,36 @@ import plant3 from '../../assets/plant3.png';
 import plant4 from '../../assets/plant4.png';
 import plant5 from '../../assets/plant5.png';
 
-const ProfileImage = () => {
+const ProfileImage = ({otherUser}) => {
     const { user } = useAuth();
     const [img, setImg] = useState(plant0);
 
+    const propOtherUser = otherUser;
+
+    const [selectedUserImg, setSelectedUser] = useState(user.profileImage);
+
+    useEffect(() => {
+        if (propOtherUser) {
+            setSelectedUser(propOtherUser.profileImage)
+        }
+        currentProfileImage();
+    }, [propOtherUser]);
+
     const currentProfileImage = () => {
-        if (user.profileImage === 0) {
+        if (selectedUserImg === 0) {
             setImg(plant0);
-        } else if (user.profileImage === 1) {
+        } else if (selectedUserImg === 1) {
             setImg(plant1)
-        } else if (user.profileImage === 2) {
+        } else if (selectedUserImg === 2) {
             setImg(plant2)
-        } else if (user.profileImage === 3) {
+        } else if (selectedUserImg === 3) {
             setImg(plant3)
-        } else if (user.profileImage === 4) {
+        } else if (selectedUserImg === 4) {
             setImg(plant4)
-        } else if (user.profileImage === 5) {
+        } else if (selectedUserImg === 5) {
             setImg(plant5)
         }
     }
-
-    useEffect(() => {
-        currentProfileImage();
-    }, [])
 
     return (
         <div className='profileImg-div'>

--- a/ThirdPlace-UI/src/components/user/ProfileInfoCard.jsx
+++ b/ThirdPlace-UI/src/components/user/ProfileInfoCard.jsx
@@ -57,9 +57,15 @@ export default function ProfileInfoCard({otherUser}) {
               </p>
             </div>
             <div className="score-and-table">
-              <div className={user.cherryPoints > 0 ? 'cherry-score-component-div-green' : 'cherry-score-component-div-red'}>
-                <CherryScoreBadge/>
-              </div>
+              {propOtherUser ? (
+                <div className={propOtherUser.cherryPoints > 0 ? 'cherry-score-component-div-green' : 'cherry-score-component-div-red'}>
+                  <CherryScoreBadge otherUser={otherUser}/>
+                </div>
+              ) : (
+                <div className={user.cherryPoints > 0 ? 'cherry-score-component-div-green' : 'cherry-score-component-div-red'}>
+                  <CherryScoreBadge/>
+                </div>
+              )}
               <div className="profile-card-table"> 
                 <table className="table table-bordered">
                   <tbody>

--- a/ThirdPlace-UI/src/components/user/ProfileInfoCard.jsx
+++ b/ThirdPlace-UI/src/components/user/ProfileInfoCard.jsx
@@ -51,7 +51,7 @@ export default function ProfileInfoCard({otherUser}) {
         <div className="contains-all-but-buttons">
           <section className="img-cherry-score">
             <div>
-              <ProfileImage/>
+              <ProfileImage otherUser={otherUser}/>
               <p className="gray-text-edit">
                 <center>🍒 Powered by Cherry Systems</center>
               </p>
@@ -95,7 +95,7 @@ export default function ProfileInfoCard({otherUser}) {
             </div>
           </section>
         </div>
-        {( propOtherUser && propOtherUser.username !== user.username) ? "" : (
+        {(propOtherUser && propOtherUser.username !== user.username) ? "" : (
           <span className="profileInfoCard-buttons">
               <button 
                 className="submit-button" 

--- a/ThirdPlace-UI/src/components/user/ProfileInfoCard.jsx
+++ b/ThirdPlace-UI/src/components/user/ProfileInfoCard.jsx
@@ -89,7 +89,7 @@ export default function ProfileInfoCard({otherUser}) {
             </div>
           </section>
         </div>
-        {propOtherUser ? "" : (
+        {( propOtherUser && propOtherUser.username !== user.username) ? "" : (
           <span className="profileInfoCard-buttons">
               <button 
                 className="submit-button" 

--- a/ThirdPlace-UI/src/components/user/ProfileInfoCard.jsx
+++ b/ThirdPlace-UI/src/components/user/ProfileInfoCard.jsx
@@ -5,9 +5,11 @@ import UpdateUserForm from "./UpdateUserForm";
 import ProfileImage from "./ProfileImage";
 import { CherryScoreBadge } from "./CherryScoreBadge";
 
-export default function ProfileInfoCard() {
+export default function ProfileInfoCard({otherUser}) {
   const { user } = useAuth();
   const [editMode, setEditMode] = useState(false);
+
+  const propOtherUser = otherUser;
 
   const handleUpdate = async (e) => {
     e.preventDefault();
@@ -63,11 +65,19 @@ export default function ProfileInfoCard() {
                   <tbody>
                     <tr>
                       <th scope="row">Username:</th>
-                      <td>{user.username}</td>
+                      {propOtherUser ? (
+                        <td>{propOtherUser.username}</td>
+                      ) : (
+                        <td>{user.username}</td>
+                      )}
                     </tr>
                     <tr>
                       <th scope="row">Email:</th>
-                      <td>{user.email}</td>
+                      {propOtherUser ? (
+                        <td>{propOtherUser.email}</td>
+                      ) : (
+                        <td>{user.email}</td>
+                      )}
                     </tr>
                     <tr>
                       <th scope="row">Password:</th>
@@ -79,20 +89,22 @@ export default function ProfileInfoCard() {
             </div>
           </section>
         </div>
-        <span className="profileInfoCard-buttons">
-            <button 
-              className="submit-button" 
-              onClick={handleUpdate}>
-              Edit
-            </button>
-            <button
-              className="delete-button"
-              value={user.id}
-              onClick={handleDelete}
-              >
-              Delete
-            </button>
-        </span>
+        {propOtherUser ? "" : (
+          <span className="profileInfoCard-buttons">
+              <button 
+                className="submit-button" 
+                onClick={handleUpdate}>
+                Edit
+              </button>
+              <button
+                className="delete-button"
+                value={user.id}
+                onClick={handleDelete}
+                >
+                Delete
+              </button>
+          </span>
+        )}
       </section>
       ) : (
         <UpdateUserForm/>

--- a/ThirdPlace-UI/src/main.jsx
+++ b/ThirdPlace-UI/src/main.jsx
@@ -33,6 +33,10 @@ const router = createBrowserRouter([
     element: <UserProfile/>
   },
   {
+    path: '/profile/:username',
+    element: <UserProfile/>
+  },
+  {
     path: '/submitlocation',
     element: <SubmitLocation/>,
   },

--- a/ThirdPlace-UI/src/main.jsx
+++ b/ThirdPlace-UI/src/main.jsx
@@ -12,6 +12,7 @@ import SubmitLocation from "./components/pages/SubmitLocation.jsx";
 import Submission from "./components/pages/Submission.jsx";
 import SearchAndList from "./components/pages/SearchAndList.jsx";
 import { AuthProvider } from "./context/AuthContext.jsx";
+import OthersUserProfile from "./components/pages/OthersUserProfile.jsx";
 
 
 const router = createBrowserRouter([
@@ -34,7 +35,7 @@ const router = createBrowserRouter([
   },
   {
     path: '/profile/:username',
-    element: <UserProfile/>
+    element: <OthersUserProfile/>
   },
   {
     path: '/submitlocation',

--- a/ThirdPlace-UI/src/service/UserServices.js
+++ b/ThirdPlace-UI/src/service/UserServices.js
@@ -14,6 +14,32 @@ export const fetchUsers = async () => {
   }
 };
 
+// Fetch user by Username
+export const getUserByUsername = async ({username}) => {
+  try {
+      const response = await axios.get (`${BASEAPIURL}/${username}`, {
+          headers: { 'Content-Type': 'application/json' },
+          withCredentials: true
+      });
+      const user = response.data;
+
+      return user;
+  } catch (error) {
+    const errorData = error.response.data;
+    let allDefaultMessages = [];
+
+    // Add all "defaultMessage" from error response to empty array to be logged in console
+    for (let i = 0; i < errorData.length; i++) {  
+      allDefaultMessages.push(errorData[i].defaultMessage);
+    }
+
+    console.error("Error fetching user!", allDefaultMessages);
+    throw error;
+      // return null;
+  };
+};
+
+
 export const registerUser = async (username, email, verifyEmail, password, verifyPassword) => {
   const userData = {
     username,

--- a/ThirdPlace-UI/src/service/UserServices.js
+++ b/ThirdPlace-UI/src/service/UserServices.js
@@ -15,11 +15,10 @@ export const fetchUsers = async () => {
 };
 
 // Fetch user by Username
-export const getUserByUsername = async ({username}) => {
+export const getUserByUsername = async (username) => {
   try {
       const response = await axios.get (`${BASEAPIURL}/${username}`, {
-          headers: { 'Content-Type': 'application/json' },
-          withCredentials: true
+        params: { username }
       });
       const user = response.data;
 


### PR DESCRIPTION
### Summary:
- Added `getUserByUsername` method to `AuthenticationController`
- Added `getUserByUsername` `axios` method to `UserServices`
- Created `OthersUserProfile` for viewing `profiles` that are not the current user
- Updated `main.jsx` to add path for `OthersUserProfile` with a path variable
- Refactored `username` text in `AdditionalUserReviews` to make it a link that goes to a `profile`
- Current user will only see `edit` and `delete` buttons on their own `profile` page
- Refactored `CherryScoreBadge` to use props for `OthersUserProfile`
- Refactored `ProfileImage` to use props for `OthersUserProfile`
- Refactored `ProfileInfoCard` with props and conditional ternary's to use for `OthersUserProfile`

### To Test:
- [x]  Login
- [x]  Click on any `submission` (anywhere) to go to it's `submission page`
- [x]  Look through user `reviews` and click on any `username` to view that users `profile`
- [x]  Other users `profiles` will look like current users `profile` but with without the `edit` and `delete` button
- [x] All seed data users have 0 `cherry points` in DB, even through they have `submissions`/`reviews`/`favorites`