### PR TITLE
120 add categorymenu to edit submission page

### DIFF
--- a/ThirdPlace-UI/src/App.css
+++ b/ThirdPlace-UI/src/App.css
@@ -95,8 +95,30 @@ small {
   background-color: white;
 }
 
+/* For update submission form */
+.current-categories-update-submission {
+  border: solid;
+  border-width: .5px;
+  border-color: rgb(194, 194, 194);
+  width: 447px;
+  margin: 0px 0px 5px 0px;
+  padding: 0px 10px 9px 10px;
+}
+
+/* For update submission form */
+.current-locationAddress-update-submission {
+  border: solid;
+  border-width: .5px;
+  border-color: rgb(194, 194, 194);
+  width: 447px;
+  margin: 0px 0px 5px 0px;
+  padding: 5px 10px;
+}
+
+/* For Location Name and Description text fields */
 .text-input-field {
   width: 447px;
+  margin: 0px 0px 5px 0px;
 }
 
 .gray-text {

--- a/ThirdPlace-UI/src/components/Map/AddressBar.jsx
+++ b/ThirdPlace-UI/src/components/Map/AddressBar.jsx
@@ -25,6 +25,7 @@ export default function AddressBar({
   setAddress,
   placeId,
   setPlaceId,
+  defaultAddressValue
 }) {
   const [autocomplete, setAutocomplete] = useState(),
   inputRef = useRef(null);
@@ -69,13 +70,15 @@ export default function AddressBar({
   return (
     <>
       <label>
-        Address: <br></br>
+        {defaultAddressValue ? "Click & Confirm or Edit Address:" : "Address: "}
+         <br></br>
         <input
           name="locationAddress"
           id="autocomplete"
           ref={inputRef}
           onChange={onPlaceChanged}
           placeholder="Enter valid address..."
+          defaultValue={defaultAddressValue ? defaultAddressValue : ""}
           className='text-input-field'
           required
         />

--- a/ThirdPlace-UI/src/components/pages/Submission.jsx
+++ b/ThirdPlace-UI/src/components/pages/Submission.jsx
@@ -170,7 +170,10 @@ export default function Submission() {
           </p>
           </section>
         ) : (
-          <UpdateSubmissionForm props={submissionByName}/>
+          <section>
+            <h1>Edit Location Info</h1>
+            <UpdateSubmissionForm props={submissionByName}/>
+          </section>
         )}
 
       </div>

--- a/ThirdPlace-UI/src/components/submission/UpdateSubmissionForm.jsx
+++ b/ThirdPlace-UI/src/components/submission/UpdateSubmissionForm.jsx
@@ -5,25 +5,27 @@ import { CategoryMenu } from './CategoryMenu';
 import { useNavigate } from 'react-router-dom';
 import AddressBar from '../Map/AddressBar';
 import Submission from '../pages/Submission';
+import CategoryBadges from './CategoryBadges';
 
 const UpdateSubmissionForm = (props) => {
 
     let data = props;
 
     // TODO: UPDATE CATEGORIES
-    // console.log(data.props);
+    console.log(data.props);
     // let catArr = data.props.categories;
-    // let something = [];
+    // let categoriesFromDatabase = [];
     // for(let i = 0; i < catArr.length; i++) {
-    //     something.push(catArr[i].id);
+    //     categoriesFromDatabase.push(catArr[i].id);
     // }
+    // console.log(categoriesFromDatabase);
 
     // const keyValuePairCategories = catArr.reduce((obj, category) => (
     //     {...obj, [ category.id ]: true}
     // ), {});
 
-
     // console.log(keyValuePairCategories);
+    // console.log(categoriesFromDatabase);
 
     const [editMode, setEditMode] = useState(true);
 
@@ -35,13 +37,12 @@ const UpdateSubmissionForm = (props) => {
     const [submissionReview, setSubmissionReview] = useState(data.props.submissionReview);
     const [selectedCategories, setSelectedCategories] = useState({});
     const [categories, setCategories] = useState([]);
-
     const navigate = useNavigate();
 
     const [submissionList, setSubmissionList] = useState([]);
 
-     // fetches an array of submission objects from database each time the form is initialized//
-     useEffect(() => {
+    // fetches an array of submission objects from database each time the form is initialized//
+    useEffect(() => {
         fetchSubmissions()
             .then(setSubmissionList)
             .catch((error) => {
@@ -60,8 +61,6 @@ const UpdateSubmissionForm = (props) => {
 
         setCategories(categoryIds);
     }, [selectedCategories]);
-
-
 
     // on form submission // 
     const handleSubmit = async (e) => {
@@ -87,58 +86,73 @@ const UpdateSubmissionForm = (props) => {
             alert("Please select a valid address from the drop down menu.");
             e.preventDefault();
         } else {
-        // if form has no empty fields and location isn't in database, edit submission, alert user submission updated, and reload SubmitLocation page
-        if (submissionName !== "" && address !== "" && description !== "" && validLocation(submissionName)) {
-            await editSubmission(data.props.id, submissionName, address, placeId, description, rating, submissionReview, categories);
-            alert("Submission successfully updated!");
-            setEditMode(false);
-            navigate('../'+submissionName, {replace: true});
-        } 
+            // if form has no empty fields and location isn't in database, edit submission, alert user submission updated, and reload SubmitLocation page
+            if (submissionName !== "" && address !== "" && description !== "" && validLocation(submissionName)) {
+                await editSubmission(data.props.id, submissionName, address, placeId, description, rating, submissionReview, categories);
+                alert("Submission successfully updated!");
+                setEditMode(false);
+                navigate('../'+submissionName, {replace: true});
+            } 
+        }
     }
-}
 
     return (
         <>
         {editMode ? (
-            <form
-            onSubmit={handleSubmit}
-            >
-                <div className="form-group">
-                    <label>Location Name: <br></br>
-                        <input 
-                        type="text" 
-                        name="submissionName" 
-                        // placeholder='Write location name...'
-                        value={submissionName} 
-                        onChange={(e) => setSubmissionName(e.target.value)} 
-                        required
-                        />
+            <section className='review-card-new-submission'>
+                <form
+                onSubmit={handleSubmit}
+                >
+                    <div className="form-group">
+                        <label>Location Name: <br></br>
+                            <input 
+                            type="text" 
+                            name="submissionName" 
+                            // placeholder='Write location name...'
+                            value={submissionName} 
+                            onChange={(e) => setSubmissionName(e.target.value)}
+                            className='text-input-field'
+                            required
+                            />
+                        </label>
+                    </div>
+                    <label>Current Address: <br/>
+                        <div className='current-locationAddress-update-submission'>
+                            {data.props.locationAddress}
+                        </div>
                     </label>
-                </div>
-                <div className="form-group">
-                    <AddressBar address={address} setAddress={setAddress} placeId={placeId} setPlaceId={setPlaceId} />
-                </div>
-                <div className="form-group">
-                    <label>Description: <br></br>
-                        <textarea 
-                        type="text" 
-                        rows="4"
-                        name="description" 
-                        // placeholder='Write a description...'
-                        value={description}
-                        onChange={(e) => setDescription(e.target.value)} 
-                        required/>
+                    <div className="form-group">
+                        <AddressBar address={address} setAddress={setAddress} placeId={placeId} setPlaceId={setPlaceId} />
+                    </div>
+                    <div className="form-group">
+                        <label>Description: <br></br>
+                            <textarea 
+                            type="text" 
+                            rows="4"
+                            cols="50"
+                            name="description" 
+                            // placeholder='Write a description...'
+                            value={description}
+                            onChange={(e) => setDescription(e.target.value)} 
+                            required/>
+                        </label>
+                    </div>
+                    <label>Current Categories: <br/>
+                        <div className='current-categories-update-submission'>
+                            <CategoryBadges props={props.props}/>
+                        </div>
                     </label>
-                </div>
-                    <CategoryMenu selectedCategories={selectedCategories} setSelectedCategories={setSelectedCategories}/>
-                <br></br>
-                <div>
-                    <RateAndReview rating={rating} setRating={setRating} submissionReview={submissionReview} setSubmissionReview={setSubmissionReview}/>
-                </div>
-                
-                <button type="submit" className="submit-button">Submit Location</button>
+                    <label>Select New Categories: </label>
+                        <CategoryMenu selectedCategories={selectedCategories} setSelectedCategories={setSelectedCategories}/>
+                    <br/>
+                    <div>
+                        <RateAndReview rating={rating} setRating={setRating} submissionReview={submissionReview} setSubmissionReview={setSubmissionReview}/>
+                    </div>
+                    
+                    <button type="submit" className="submit-button">Submit Location</button>
 
-            </form>
+                </form>
+            </section>
             ) : (
                 <Submission />
             )}

--- a/ThirdPlace-UI/src/components/submission/UpdateSubmissionForm.jsx
+++ b/ThirdPlace-UI/src/components/submission/UpdateSubmissionForm.jsx
@@ -29,6 +29,7 @@ const UpdateSubmissionForm = (props) => {
 
     const [editMode, setEditMode] = useState(true);
 
+    const [defaultAddressValue, setDefaultAddressValue] = useState(data.props.locationAddress);
     const [address, setAddress] = useState("");
     const [placeId, setPlaceId] = useState("");
     const [submissionName, setSubmissionName] = useState(data.props.locationName);
@@ -122,7 +123,7 @@ const UpdateSubmissionForm = (props) => {
                         </div>
                     </label>
                     <div className="form-group">
-                        <AddressBar address={address} setAddress={setAddress} placeId={placeId} setPlaceId={setPlaceId} />
+                        <AddressBar address={address} setAddress={setAddress} placeId={placeId} setPlaceId={setPlaceId} defaultAddressValue={defaultAddressValue}/>
                     </div>
                     <div className="form-group">
                         <label>Description: <br></br>
@@ -142,7 +143,7 @@ const UpdateSubmissionForm = (props) => {
                             <CategoryBadges props={props.props}/>
                         </div>
                     </label>
-                    <label>Select New Categories: </label>
+                    <label>Select New Categories & Categories to Keep : </label>
                         <CategoryMenu selectedCategories={selectedCategories} setSelectedCategories={setSelectedCategories}/>
                     <br/>
                     <div>


### PR DESCRIPTION
### Summary:
- Updated CSS for `update submission form` styling
- Added sections that populate `current address` and `current categories` into `update submission form`
- Added code to make the `Address` field in `update submission form` have a `defaultValue` as the current `locationName` if one is present, and an empty string otherwise
- Refactored `addressBar` label to say "Click & Confirm or Edit Address:" if a `defaultValue` is present
- Added title to `update submission form`

### To Test:
- [x] Login
- [x] Click on any of your own `submissions`
- [x] Scroll to bottom of page and click on the `edit` button
- [x] All form fields should be populated with current `submissions` info, `CategoryMenu` dropdown will not have any boxes checked
- [x] To select new `categories`, you will need to check the new categories to add and the current ones you want to keep
- [x] You should be able to change all fields except `Location Name`